### PR TITLE
Remove bundled WASM

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,8 @@
 # Drawing Viewer (React + Vite)
 
-This simple frontend app lets you test importing and displaying drawing files. PDF files are rendered with [`pdfjs-dist`](https://github.com/mozilla/pdf.js). DWG files currently show a placeholder message.
+This simple frontend app lets you test importing and displaying drawing files. PDF files are rendered with [`pdfjs-dist`](https://github.com/mozilla/pdf.js). DWG files are converted to SVG with [`@mlightcad/libredwg-web`](https://www.npmjs.com/package/@mlightcad/libredwg-web).
+
+The viewer loads the library's WebAssembly module directly from the package, so no large binaries are stored in the repository.
 
 ## Development
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@mlightcad/libredwg-web": "^0.1.5",
         "pdfjs-dist": "^5.3.31",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -1017,6 +1018,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mlightcad/libredwg-web": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@mlightcad/libredwg-web/-/libredwg-web-0.1.5.tgz",
+      "integrity": "sha512-OmQD0Gf7q7cBzg9yEnsYJutwz0vl157aeGG63elxtkX6cI/YDLuqNS3FjGt3dYs9XwtgAzpMQL/gAPhG5K+7jw==",
+      "license": "GPL-2.0-only"
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.70",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "pdfjs-dist": "^5.3.31",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@mlightcad/libredwg-web": "^0.1.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import PdfViewer from './PdfViewer.jsx'
+import DwgViewer from './DwgViewer.jsx'
 import './App.css'
 
 function App() {
@@ -19,9 +20,7 @@ function App() {
       <h1>Drawing Viewer</h1>
       <input type="file" accept=".pdf,.dwg" onChange={handleFile} />
       {file && fileType === 'pdf' && <PdfViewer file={file} />}
-      {file && fileType === 'dwg' && (
-        <p>DWG viewing is not currently supported.</p>
-      )}
+      {file && fileType === 'dwg' && <DwgViewer file={file} />}
       {file && !['pdf', 'dwg'].includes(fileType) && (
         <p>Unsupported file type.</p>
       )}

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import { createModule, LibreDwg, Dwg_File_Type } from '@mlightcad/libredwg-web'
+import wasmUrl from '../node_modules/@mlightcad/libredwg-web/wasm/libredwg-web.wasm?url'
+
+export default function DwgViewer({ file }) {
+  const [svg, setSvg] = useState(null)
+
+  useEffect(() => {
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = async () => {
+      const wasmInstance = await createModule({
+        locateFile: (path) => (path.endsWith('.wasm') ? wasmUrl : path),
+      })
+      const libredwg = LibreDwg.createByWasmInstance(wasmInstance)
+      const dwgData = libredwg.dwg_read_data(reader.result, Dwg_File_Type.DWG)
+      const db = libredwg.convert(dwgData)
+      libredwg.dwg_free(dwgData)
+      const svgStr = libredwg.dwg_to_svg(db)
+      setSvg(svgStr)
+    }
+    reader.readAsArrayBuffer(file)
+  }, [file])
+
+  return svg ? (
+    <div className="dwg-container" dangerouslySetInnerHTML={{ __html: svg }} />
+  ) : null
+}


### PR DESCRIPTION
## Summary
- delete `libredwg-web.wasm` binary from `public`
- reference the WASM from `@mlightcad/libredwg-web`
- mention that the WebAssembly module is loaded from the package in the README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842e191d1bc8331b1d46dc2004814ae