### PR TITLE
Add layer sidebar with select-all

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -45,12 +45,27 @@
   margin-bottom: 1rem;
 }
 
+.dwg-viewer {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.dwg-sidebar {
+  width: 200px;
+  border: 1px solid #888;
+  padding: 0.5rem;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
 .dwg-layers {
   margin-bottom: 1rem;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: center;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: flex-start;
 }
 
 .dwg-container {
@@ -58,3 +73,4 @@
   overflow: auto;
   display: inline-block;
 }
+


### PR DESCRIPTION
## Summary
- create sidebar layout for DWG layer controls
- add select all checkbox for layers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842f25dbe9883319b521436cbdfaadf