### PR TITLE
Add DWG rotation control

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,3 +12,10 @@ npm run dev
 ```
 
 Open your browser at the printed local address to use the app.
+
+## Features
+
+- Zoom and pan DWG drawings.
+- Toggle individual layers on or off.
+- Rotate the drawing in 15° increments with the new rotate buttons.
+- Viewer area expands to nearly the full height of the browser window by default.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -72,5 +72,6 @@
   border: 1px solid #888;
   overflow: auto;
   display: inline-block;
+  height: 90vh;
 }
 

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -8,6 +8,7 @@ export default function DwgViewer({ file }) {
   const [layers, setLayers] = useState([])
   const [visibleLayers, setVisibleLayers] = useState(new Set())
   const [zoom, setZoom] = useState(1)
+  const [rotation, setRotation] = useState(0)
   const selectAllRef = useRef(null)
 
   useEffect(() => {
@@ -59,6 +60,8 @@ export default function DwgViewer({ file }) {
 
   const zoomIn = () => setZoom((z) => z * 1.2)
   const zoomOut = () => setZoom((z) => z / 1.2)
+  const rotateLeft = () => setRotation((r) => r - 15)
+  const rotateRight = () => setRotation((r) => r + 15)
 
   const toggleAllLayers = (checked) => {
     if (checked) setVisibleLayers(new Set(layers))
@@ -73,6 +76,8 @@ export default function DwgViewer({ file }) {
         <div className="dwg-controls">
           <button onClick={zoomOut}>-</button>
           <button onClick={zoomIn}>+</button>
+          <button onClick={rotateLeft}>⟲</button>
+          <button onClick={rotateRight}>⟳</button>
         </div>
         <div className="dwg-layers">
           <label>
@@ -98,7 +103,10 @@ export default function DwgViewer({ file }) {
       </div>
       <div
         className="dwg-container"
-        style={{ transform: `scale(${zoom})`, transformOrigin: 'top left' }}
+        style={{
+          transform: `scale(${zoom}) rotate(${rotation}deg)`,
+          transformOrigin: 'center',
+        }}
         dangerouslySetInnerHTML={{ __html: svg }}
       />
     </div>


### PR DESCRIPTION
## Summary
- expand drawing area height
- add rotation control to DWG viewer
- document new features

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842f981bad88331a6ed82431191caea