### PR TITLE
Fix viewer sizing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -53,7 +53,7 @@
 }
 
 .dwg-sidebar {
-  width: 200px;
+  width: 250px;
   border: 1px solid #888;
   padding: 0.5rem;
   max-height: 80vh;
@@ -73,5 +73,6 @@
   overflow: auto;
   display: inline-block;
   height: 90vh;
+  width: 70vw;
 }
 


### PR DESCRIPTION
## Summary
- keep DWG viewer container fixed size so it doesn't resize to the drawing
- increase sidebar width for easier navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68430392ccfc8331b85899a23af6329d