### PR TITLE
Add PDF zoom controls and DWG resets

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -85,3 +85,39 @@
   width: 70vw;
 }
 
+.pdf-viewer {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.pdf-container {
+  border: 1px solid #888;
+  overflow: auto;
+  display: inline-block;
+  height: 90vh;
+  width: 70vw;
+}
+
+.pdf-sidebar {
+  width: 250px;
+  border: 1px solid #888;
+  padding: 0.5rem;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.pdf-controls {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.pdf-controls > div {
+  display: flex;
+  gap: 0.5rem;
+}
+

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -61,8 +61,10 @@ export default function DwgViewer({ file }) {
 
   const zoomIn = () => setZoom((z) => z * 1.2)
   const zoomOut = () => setZoom((z) => z / 1.2)
+  const resetZoom = () => setZoom(1)
   const rotateLeft = () => setRotation((r) => r - 5)
   const rotateRight = () => setRotation((r) => r + 5)
+  const resetRotation = () => setRotation(0)
 
   useEffect(() => {
     if (!svgContainerRef.current) return
@@ -91,10 +93,12 @@ export default function DwgViewer({ file }) {
         <div className="dwg-controls">
           <div className="zoom-controls">
             <button onClick={zoomOut}>-</button>
+            <button onClick={resetZoom}>reset</button>
             <button onClick={zoomIn}>+</button>
           </div>
           <div className="rotate-controls">
             <button onClick={rotateLeft}>⟲</button>
+            <button onClick={resetRotation}>reset</button>
             <button onClick={rotateRight}>⟳</button>
           </div>
         </div>

--- a/frontend/src/PdfViewer.jsx
+++ b/frontend/src/PdfViewer.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { GlobalWorkerOptions, getDocument } from 'pdfjs-dist'
 import pdfWorker from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
 
@@ -7,6 +7,11 @@ GlobalWorkerOptions.workerSrc = pdfWorker
 
 export default function PdfViewer({ file }) {
   const canvasRef = useRef(null)
+  const [page, setPage] = useState(null)
+  const [zoom, setZoom] = useState(1)
+
+  const zoomIn = () => setZoom((z) => z * 1.2)
+  const zoomOut = () => setZoom((z) => z / 1.2)
 
   useEffect(() => {
     if (!file) return
@@ -14,16 +19,36 @@ export default function PdfViewer({ file }) {
     reader.onload = async () => {
       const typedarray = new Uint8Array(reader.result)
       const pdf = await getDocument({ data: typedarray }).promise
-      const page = await pdf.getPage(1)
-      const viewport = page.getViewport({ scale: 1.5 })
-      const canvas = canvasRef.current
-      canvas.height = viewport.height
-      canvas.width = viewport.width
-      const context = canvas.getContext('2d')
-      await page.render({ canvasContext: context, viewport }).promise
+      const firstPage = await pdf.getPage(1)
+      setPage(firstPage)
     }
     reader.readAsArrayBuffer(file)
   }, [file])
 
-  return <canvas ref={canvasRef} />
+  useEffect(() => {
+    if (!page) return
+    const viewport = page.getViewport({ scale: zoom })
+    const canvas = canvasRef.current
+    canvas.height = viewport.height
+    canvas.width = viewport.width
+    const context = canvas.getContext('2d')
+    context.clearRect(0, 0, canvas.width, canvas.height)
+    page.render({ canvasContext: context, viewport })
+  }, [page, zoom])
+
+  return page ? (
+    <div className="pdf-viewer">
+      <div className="pdf-container">
+        <canvas ref={canvasRef} />
+      </div>
+      <div className="pdf-sidebar">
+        <div className="pdf-controls">
+          <div className="zoom-controls">
+            <button onClick={zoomOut}>-</button>
+            <button onClick={zoomIn}>+</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : null
 }


### PR DESCRIPTION
## Summary
- add zoom and sidebar layout for PDF viewer
- add reset zoom/rotation controls for DWG viewer
- style PDF viewer similar to DWG viewer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684315fe753c83318cca02b4d610a9b0