### PR TITLE
Adjust DWG layer sidebar alignment

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -62,11 +62,12 @@
 }
 
 .dwg-sidebar {
-  width: 250px;
+  width: 320px;
   border: 1px solid #888;
   padding: 0.5rem;
   max-height: 80vh;
   overflow-y: auto;
+  text-align: left;
 }
 
 .dwg-layers {
@@ -75,6 +76,12 @@
   flex-direction: column;
   gap: 0.25rem;
   align-items: flex-start;
+}
+
+.dwg-layers label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .dwg-container {


### PR DESCRIPTION
## Summary
- widen DWG sidebar to show longer layer names
- left-align layer checkboxes and text for readability

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684317d076d88331b3e943ea2b734fd6