### PR TITLE
Add layer previews and panning

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,7 +65,7 @@
   width: 320px;
   border: 1px solid #888;
   padding: 0.5rem;
-  max-height: 80vh;
+  height: 90vh;
   overflow-y: auto;
   text-align: left;
 }
@@ -126,5 +126,17 @@
 .pdf-controls > div {
   display: flex;
   gap: 0.5rem;
+}
+
+.layer-preview {
+  width: 48px;
+  height: 48px;
+  border: 1px solid #ccc;
+  overflow: hidden;
+}
+
+.layer-preview svg {
+  width: 100%;
+  height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- match DWG sidebar height to viewer
- show a preview next to each layer
- allow panning the drawing via mouse drag

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68431a544e5483318ce11d12462d7797