### PR TITLE
Add pan improvements and loading spinner

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -103,10 +103,12 @@
 
 .pdf-container {
   border: 1px solid #888;
-  overflow: auto;
+  overflow: hidden;
   display: inline-block;
   height: 90vh;
   width: 70vw;
+  cursor: grab;
+  position: relative;
 }
 
 .pdf-sidebar {
@@ -140,5 +142,14 @@
 .layer-preview svg {
   width: 100%;
   height: 100%;
+  object-fit: contain;
+}
+
+.dwg-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 90vh;
+  font-size: 1.5rem;
 }
 

--- a/frontend/src/PdfViewer.jsx
+++ b/frontend/src/PdfViewer.jsx
@@ -9,6 +9,8 @@ export default function PdfViewer({ file }) {
   const canvasRef = useRef(null)
   const [page, setPage] = useState(null)
   const [zoom, setZoom] = useState(1)
+  const [pan, setPan] = useState({ x: 0, y: 0 })
+  const panState = useRef(null)
 
   const zoomIn = () => setZoom((z) => z * 1.2)
   const zoomOut = () => setZoom((z) => z / 1.2)
@@ -35,6 +37,47 @@ export default function PdfViewer({ file }) {
     context.clearRect(0, 0, canvas.width, canvas.height)
     page.render({ canvasContext: context, viewport })
   }, [page, zoom])
+
+  useEffect(() => {
+    if (!canvasRef.current) return
+    const canvas = canvasRef.current
+    canvas.style.transform = `translate(${pan.x}px, ${pan.y}px)`
+  }, [pan])
+
+  useEffect(() => {
+    const container = canvasRef.current?.parentElement
+    if (!container) return
+    const handleDown = (e) => {
+      panState.current = {
+        x: e.clientX,
+        y: e.clientY,
+        startX: pan.x,
+        startY: pan.y,
+      }
+      container.style.cursor = 'grabbing'
+    }
+    const handleMove = (e) => {
+      if (!panState.current) return
+      const dx = e.clientX - panState.current.x
+      const dy = e.clientY - panState.current.y
+      setPan({ x: panState.current.startX + dx, y: panState.current.startY + dy })
+    }
+    const handleUp = () => {
+      panState.current = null
+      container.style.cursor = 'grab'
+    }
+    container.addEventListener('pointerdown', handleDown)
+    container.addEventListener('pointermove', handleMove)
+    container.addEventListener('pointerup', handleUp)
+    container.addEventListener('pointerleave', handleUp)
+    container.style.cursor = 'grab'
+    return () => {
+      container.removeEventListener('pointerdown', handleDown)
+      container.removeEventListener('pointermove', handleMove)
+      container.removeEventListener('pointerup', handleUp)
+      container.removeEventListener('pointerleave', handleUp)
+    }
+  }, [pan.x, pan.y])
 
   return page ? (
     <div className="pdf-viewer">


### PR DESCRIPTION
## Summary
- fix DWG viewer pan event state updates and use pointer events
- normalize layer preview SVGs before setting to 48x48
- add loading indicator while DWG files are processed
- support panning in PDF viewer
- tweak preview styles and pdf container for consistent sizing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68433040de688331845138610c2dbfd1