### PR TITLE
Enable PDF dragging

### DIFF
--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -129,7 +129,7 @@ export default function DwgViewer({ file }) {
       container.removeEventListener('pointerup', handleUp)
       container.removeEventListener('pointerleave', handleUp)
     }
-  }, [pan.x, pan.y])
+  }, [svg])
 
   const toggleAllLayers = (checked) => {
     if (checked) setVisibleLayers(new Set(layers))

--- a/frontend/src/PdfViewer.jsx
+++ b/frontend/src/PdfViewer.jsx
@@ -75,7 +75,7 @@ export default function PdfViewer({ file }) {
       container.removeEventListener('mouseleave', endDrag)
       window.removeEventListener('mouseup', endDrag)
     }
-  }, [])
+  }, [page])
 
   useEffect(() => {
     const container = containerRef.current


### PR DESCRIPTION
## Summary
- fix useEffect dependencies so panning handlers mount when PDF/svg loads

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844495e82a8833190e626276cb2068b