### PR TITLE
Improve DWG viewer zoom stability and UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -54,6 +54,12 @@
   gap: 0.5rem;
 }
 
+.zoom-indicator {
+  display: inline-block;
+  min-width: 3ch;
+  text-align: right;
+}
+
 .dwg-viewer {
   display: flex;
   gap: 1rem;
@@ -74,6 +80,8 @@
   position: relative;
   width: 100%;
   margin-bottom: 0.5rem;
+  border: 1px solid #888;
+  padding: 0.25rem;
 }
 
 .dwg-mini svg {

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -91,6 +91,11 @@ export default function DwgViewer({ file }) {
 
   useEffect(() => {
     if (!svgContainerRef.current) return
+    svgContainerRef.current.innerHTML = svg
+  }, [svg])
+
+  useEffect(() => {
+    if (!svgContainerRef.current) return
     const el = svgContainerRef.current.querySelector('svg')
     if (el) {
       el.style.transform = `translate(${pan.x}px, ${pan.y}px) scale(${zoom}) rotate(${rotation}deg)`
@@ -141,7 +146,7 @@ export default function DwgViewer({ file }) {
       })
     }
     update()
-  }, [zoom, pan])
+  }, [svg, zoom, pan])
 
   useEffect(() => {
     const container = svgContainerRef.current
@@ -203,11 +208,7 @@ export default function DwgViewer({ file }) {
 
   return svg ? (
     <div className="dwg-viewer">
-      <div
-        className="dwg-container"
-        ref={svgContainerRef}
-        dangerouslySetInnerHTML={{ __html: svg }}
-      />
+      <div className="dwg-container" ref={svgContainerRef} />
       <div className="dwg-sidebar">
         <div className="dwg-mini-wrapper" ref={miniRef}>
           <div className="dwg-mini" />
@@ -226,6 +227,7 @@ export default function DwgViewer({ file }) {
             <button onClick={zoomOut}>-</button>
             <button onClick={resetZoom}>reset</button>
             <button onClick={zoomIn}>+</button>
+            <span className="zoom-indicator">{Math.round(zoom * 100)}%</span>
           </div>
           <div className="rotate-controls">
             <button onClick={rotateLeft}>⟲</button>


### PR DESCRIPTION
## Summary
- avoid replacing SVG element on every render so zoom stays persistent
- draw border around DWG mini view
- show zoom percentage in DWG viewer

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68446a3f484883319ffcb74905516fa2