### PR TITLE
Improve DWG viewer UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -49,15 +49,28 @@
   align-items: flex-start;
 }
 
+
 .dwg-controls > div {
   display: flex;
   gap: 0.5rem;
 }
 
+.zoom-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.zoom-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .zoom-indicator {
-  display: inline-block;
+  display: block;
   min-width: 3ch;
-  text-align: right;
+  text-align: center;
 }
 
 .dwg-viewer {
@@ -76,12 +89,15 @@
   text-align: left;
 }
 
-.dwg-mini-wrapper {
-  position: relative;
-  width: 100%;
-  margin-bottom: 0.5rem;
+.dwg-mini-window {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 220px;
   border: 1px solid #888;
   padding: 0.25rem;
+  background: #fff;
+  z-index: 10;
 }
 
 .dwg-mini svg {
@@ -95,6 +111,7 @@
   border: 2px solid red;
   pointer-events: none;
   box-sizing: border-box;
+  z-index: 1;
 }
 
 .dwg-layers {
@@ -109,6 +126,18 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
+}
+
+.layers-header {
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.layers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 .dwg-container {
@@ -175,10 +204,7 @@
   align-items: flex-start;
 }
 
-.pdf-controls > div {
-  display: flex;
-  gap: 0.5rem;
-}
+
 
 
 .dwg-loading {

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -21,6 +21,7 @@ export default function DwgViewer({ file }) {
   const [rotation, setRotation] = useState(0)
   const [pan, setPan] = useState({ x: 0, y: 0 })
   const [overlay, setOverlay] = useState({ left: 0, top: 0, width: 0, height: 0 })
+  const [layersOpen, setLayersOpen] = useState(true)
   const [loading, setLoading] = useState(false)
   const selectAllRef = useRef(null)
   const svgContainerRef = useRef(null)
@@ -146,7 +147,7 @@ export default function DwgViewer({ file }) {
       })
     }
     update()
-  }, [svg, zoom, pan])
+  }, [svg, zoom, pan, rotation])
 
   useEffect(() => {
     const container = svgContainerRef.current
@@ -210,23 +211,13 @@ export default function DwgViewer({ file }) {
     <div className="dwg-viewer">
       <div className="dwg-container" ref={svgContainerRef} />
       <div className="dwg-sidebar">
-        <div className="dwg-mini-wrapper" ref={miniRef}>
-          <div className="dwg-mini" />
-          <div
-            className="dwg-mini-overlay"
-            style={{
-              left: overlay.left,
-              top: overlay.top,
-              width: overlay.width,
-              height: overlay.height,
-            }}
-          />
-        </div>
         <div className="dwg-controls">
           <div className="zoom-controls">
-            <button onClick={zoomOut}>-</button>
-            <button onClick={resetZoom}>reset</button>
-            <button onClick={zoomIn}>+</button>
+            <div className="zoom-buttons">
+              <button onClick={zoomOut}>-</button>
+              <button onClick={resetZoom}>reset</button>
+              <button onClick={zoomIn}>+</button>
+            </div>
             <span className="zoom-indicator">{Math.round(zoom * 100)}%</span>
           </div>
           <div className="rotate-controls">
@@ -236,26 +227,48 @@ export default function DwgViewer({ file }) {
           </div>
         </div>
         <div className="dwg-layers">
-          <label>
-            <input
-              type="checkbox"
-              ref={selectAllRef}
-              checked={allSelected}
-              onChange={(e) => toggleAllLayers(e.target.checked)}
-            />
-            Select All
-          </label>
-          {layers.map((l) => (
-            <label key={l}>
-              <input
-                type="checkbox"
-                checked={visibleLayers.has(l)}
-                onChange={() => toggleLayer(l)}
-              />
-              {l}
-            </label>
-          ))}
+          <div
+            className="layers-header"
+            onClick={() => setLayersOpen((o) => !o)}
+          >
+            Layers {layersOpen ? '▾' : '▸'}
+          </div>
+          {layersOpen && (
+            <div className="layers-list">
+              <label>
+                <input
+                  type="checkbox"
+                  ref={selectAllRef}
+                  checked={allSelected}
+                  onChange={(e) => toggleAllLayers(e.target.checked)}
+                />
+                Select All
+              </label>
+              {layers.map((l) => (
+                <label key={l}>
+                  <input
+                    type="checkbox"
+                    checked={visibleLayers.has(l)}
+                    onChange={() => toggleLayer(l)}
+                  />
+                  {l}
+                </label>
+              ))}
+            </div>
+          )}
         </div>
+      </div>
+      <div className="dwg-mini-window" ref={miniRef}>
+        <div className="dwg-mini" />
+        <div
+          className="dwg-mini-overlay"
+          style={{
+            left: overlay.left,
+            top: overlay.top,
+            width: overlay.width,
+            height: overlay.height,
+          }}
+        />
       </div>
     </div>
   ) : null

--- a/frontend/src/PdfViewer.jsx
+++ b/frontend/src/PdfViewer.jsx
@@ -150,9 +150,11 @@ export default function PdfViewer({ file }) {
         </div>
         <div className="pdf-controls">
           <div className="zoom-controls">
-            <button onClick={zoomOut}>-</button>
-            <button onClick={resetZoom}>reset</button>
-            <button onClick={zoomIn}>+</button>
+            <div className="zoom-buttons">
+              <button onClick={zoomOut}>-</button>
+              <button onClick={resetZoom}>reset</button>
+              <button onClick={zoomIn}>+</button>
+            </div>
             <span className="zoom-indicator">{Math.round(zoom * 100)}%</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add floating mini window with highlighted viewport
- show zoom level under zoom buttons
- make layers panel collapsible
- adjust PDF viewer zoom controls

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68448b9ca4548331a5fa58483f98f98d