### PR TITLE
Fix DWG loading with electron

### DIFF
--- a/frontend/electron-main.js
+++ b/frontend/electron-main.js
@@ -1,7 +1,11 @@
 import { app, BrowserWindow, ipcMain } from 'electron'
 import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { createModule, LibreDwg, Dwg_File_Type } from '@mlightcad/libredwg-web'
+import { createRequire } from 'node:module'
+
+// Use the CommonJS build of libredwg-web for better Node compatibility
+const require = createRequire(import.meta.url)
+const { createModule, LibreDwg, Dwg_File_Type } = require('@mlightcad/libredwg-web')
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 


### PR DESCRIPTION
## Summary
- load `@mlightcad/libredwg-web` via `createRequire` to avoid ESM issues in Electron

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845e15c4ba4833188f09b77b2529cd9