### PR TITLE
Fix DWG loading with electron

### DIFF
--- a/frontend/electron-main.js
+++ b/frontend/electron-main.js
@@ -1,7 +1,12 @@
 import { app, BrowserWindow, ipcMain } from 'electron'
 import path, { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { createModule, LibreDwg, Dwg_File_Type } from '@mlightcad/libredwg-web'
+import { createRequire } from 'node:module'
+import { Buffer } from 'node:buffer'
+
+// Use the CommonJS build of libredwg-web for better Node compatibility
+const require = createRequire(import.meta.url)
+const { createModule, LibreDwg, Dwg_File_Type } = require('@mlightcad/libredwg-web')
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -34,6 +39,11 @@ async function createWindow() {
 app.whenReady().then(createWindow)
 
 ipcMain.handle('load-dwg', async (_evt, buffer) => {
+  // Ensure the input is a Uint8Array that libredwg can consume
+  const bytes = Buffer.isBuffer(buffer)
+    ? buffer
+    : new Uint8Array(buffer)
+
   const wasmPath = path.join(
     __dirname,
     'node_modules',
@@ -46,7 +56,7 @@ ipcMain.handle('load-dwg', async (_evt, buffer) => {
     locateFile: (p) => (p.endsWith('.wasm') ? wasmPath : p),
   })
   const libredwg = LibreDwg.createByWasmInstance(wasmInstance)
-  const dwgData = libredwg.dwg_read_data(buffer, Dwg_File_Type.DWG)
+  const dwgData = libredwg.dwg_read_data(bytes, Dwg_File_Type.DWG)
   const db = libredwg.convert(dwgData)
   libredwg.dwg_free(dwgData)
   dwgInfo = { libredwg, db }

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -20,13 +20,17 @@ export default function DwgViewer({ file }) {
     setLoading(true)
     const reader = new FileReader()
     reader.onload = async () => {
-      const { layers: layerNames, svg: initialSvg } = await window.electronApi.loadDwg(
-        reader.result
-      )
-      setLayers(layerNames)
-      setVisibleLayers(new Set(layerNames))
-      setSvg(initialSvg)
-      setLoading(false)
+      try {
+        const { layers: layerNames, svg: initialSvg } =
+          await window.electronApi.loadDwg(reader.result)
+        setLayers(layerNames)
+        setVisibleLayers(new Set(layerNames))
+        setSvg(initialSvg)
+      } catch (err) {
+        console.error('Failed to load DWG:', err)
+      } finally {
+        setLoading(false)
+      }
     }
     reader.readAsArrayBuffer(file)
   }, [file])


### PR DESCRIPTION
## Summary
- ensure DWG ArrayBuffer is converted to bytes in main process
- add error handling in `DwgViewer`

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845e15c4ba4833188f09b77b2529cd9