### PR TITLE
Improve DWG viewer detection for web builds

### DIFF
--- a/frontend/electron-preload.js
+++ b/frontend/electron-preload.js
@@ -4,3 +4,6 @@ contextBridge.exposeInMainWorld('electronApi', {
   loadDwg: (buffer) => ipcRenderer.invoke('load-dwg', buffer),
   renderDwg: (layers) => ipcRenderer.invoke('render-dwg', layers),
 })
+
+// Signal to the renderer that the API is ready
+window.dispatchEvent(new Event('electron-api-ready'))

--- a/frontend/electron-preload.js
+++ b/frontend/electron-preload.js
@@ -4,6 +4,3 @@ contextBridge.exposeInMainWorld('electronApi', {
   loadDwg: (buffer) => ipcRenderer.invoke('load-dwg', buffer),
   renderDwg: (layers) => ipcRenderer.invoke('render-dwg', layers),
 })
-
-// Signal to the renderer that the API is ready
-window.dispatchEvent(new Event('electron-api-ready'))

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState, useRef } from 'react'
 
 export default function DwgViewer({ file }) {
-  const isElectron =
-    typeof navigator !== 'undefined' &&
-    navigator.userAgent.toLowerCase().includes('electron')
-  const electronApi = isElectron ? window.electronApi : null
+  const electronApi =
+    typeof window !== 'undefined' && window.electronApi
+      ? window.electronApi
+      : null
   const hasElectron = !!electronApi
   const [svg, setSvg] = useState(null)
   const [layers, setLayers] = useState([])
@@ -42,7 +42,7 @@ export default function DwgViewer({ file }) {
       }
     }
     reader.readAsArrayBuffer(file)
-  }, [file, hasElectron])
+  }, [file, hasElectron, electronApi])
 
   useEffect(() => {
     if (!layers.length) return
@@ -50,7 +50,7 @@ export default function DwgViewer({ file }) {
       const layerList = Array.from(visibleLayers)
       electronApi.renderDwg(layerList).then(setSvg)
     }
-  }, [visibleLayers, layers, hasElectron])
+  }, [visibleLayers, layers, hasElectron, electronApi])
 
 
   useEffect(() => {

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -1,7 +1,11 @@
 import { useEffect, useState, useRef } from 'react'
 
 export default function DwgViewer({ file }) {
-  const hasElectron = typeof window !== 'undefined' && window.electronApi
+  const isElectron =
+    typeof navigator !== 'undefined' &&
+    navigator.userAgent.toLowerCase().includes('electron')
+  const electronApi = isElectron ? window.electronApi : null
+  const hasElectron = !!electronApi
   const [svg, setSvg] = useState(null)
   const [layers, setLayers] = useState([])
   const [visibleLayers, setVisibleLayers] = useState(new Set())
@@ -27,7 +31,7 @@ export default function DwgViewer({ file }) {
     reader.onload = async () => {
       try {
         const { layers: layerNames, svg: initialSvg } =
-          await window.electronApi.loadDwg(reader.result)
+          await electronApi.loadDwg(reader.result)
         setLayers(layerNames)
         setVisibleLayers(new Set(layerNames))
         setSvg(initialSvg)
@@ -44,7 +48,7 @@ export default function DwgViewer({ file }) {
     if (!layers.length) return
     if (hasElectron) {
       const layerList = Array.from(visibleLayers)
-      window.electronApi.renderDwg(layerList).then(setSvg)
+      electronApi.renderDwg(layerList).then(setSvg)
     }
   }, [visibleLayers, layers, hasElectron])
 

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -21,16 +21,21 @@ export default function DwgViewer({ file }) {
   const miniRef = useRef(null)
   const panState = useRef(null)
 
-  // Grab the Electron API once the preload script signals readiness
+  // Grab the Electron API when it becomes available
   useEffect(() => {
     if (electronApi || typeof window === 'undefined') return
-    const handler = () => {
-      if (window.electronApi) setElectronApi(window.electronApi)
+    const attempt = () => {
+      if (window.electronApi) {
+        setElectronApi(window.electronApi)
+        return true
+      }
+      return false
     }
-    window.addEventListener('electron-api-ready', handler)
-    // Check in case the event fired before listener registration
-    if (window.electronApi) handler()
-    return () => window.removeEventListener('electron-api-ready', handler)
+    if (attempt()) return
+    const id = setInterval(() => {
+      if (attempt()) clearInterval(id)
+    }, 100)
+    return () => clearInterval(id)
   }, [electronApi])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- detect whether the app is running under Electron before trying to load a DWG file
- show an error message when running the web build

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845e860e5848331b9149dc4e18cc2be