### PR TITLE
Add JPG support and UI tweaks

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -96,6 +96,13 @@
   margin-bottom: 0.5rem;
 }
 
+.dwg-mini-section,
+.pdf-mini-section {
+  border-bottom: 1px solid #888;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .dwg-mini {
   width: 100%;
   display: block;
@@ -203,6 +210,21 @@
   flex-direction: column;
   gap: 0.5rem;
   align-items: flex-start;
+}
+
+.img-container {
+  border: 1px solid #888;
+  overflow: auto;
+  display: inline-block;
+  height: 90vh;
+  width: 70vw;
+}
+
+.img-container img {
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+  margin: 0 auto;
 }
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { AppBar, Toolbar, Typography, Container, Button, Box } from '@mui/material'
 import PdfViewer from './PdfViewer.jsx'
 import DwgViewer from './DwgViewer.jsx'
+import ImageViewer from './ImageViewer.jsx'
 import './App.css'
 
 function App() {
@@ -20,19 +21,22 @@ function App() {
     <Box className="App">
       <AppBar position="static">
         <Toolbar>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          <Typography variant="h6" sx={{ flexGrow: 1, mr: 2 }}>
             Drawing Viewer
           </Typography>
           <Button variant="contained" component="label">
             Select File
-            <input hidden type="file" accept=".pdf,.dwg" onChange={handleFile} />
+            <input hidden type="file" accept=".pdf,.dwg,.jpg,.jpeg" onChange={handleFile} />
           </Button>
         </Toolbar>
       </AppBar>
       <Container sx={{ mt: 2 }}>
         {file && fileType === 'pdf' && <PdfViewer file={file} />}
         {file && fileType === 'dwg' && <DwgViewer file={file} />}
-        {file && !['pdf', 'dwg'].includes(fileType) && (
+        {file && (fileType === 'jpg' || fileType === 'jpeg') && (
+          <ImageViewer file={file} />
+        )}
+        {file && !['pdf', 'dwg', 'jpg', 'jpeg'].includes(fileType) && (
           <Typography>Unsupported file type.</Typography>
         )}
       </Container>

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -223,17 +223,19 @@ export default function DwgViewer({ file }) {
       <Box className="dwg-viewer">
         <Box className="dwg-container" ref={svgContainerRef} />
         <Box className="dwg-sidebar">
-          <Box className="dwg-mini-wrapper" ref={miniRef}>
-            <Box className="dwg-mini" />
-            <Box
-              className="dwg-mini-overlay"
-              sx={{
-                left: overlay.left,
-                top: overlay.top,
-                width: overlay.width,
-                height: overlay.height,
-              }}
-            />
+          <Box className="dwg-mini-section">
+            <Box className="dwg-mini-wrapper" ref={miniRef}>
+              <Box className="dwg-mini" />
+              <Box
+                className="dwg-mini-overlay"
+                sx={{
+                  left: overlay.left,
+                  top: overlay.top,
+                  width: overlay.width,
+                  height: overlay.height,
+                }}
+              />
+            </Box>
             <Box className="dwg-controls">
               <Box className="zoom-controls">
                 <Box className="zoom-buttons">

--- a/frontend/src/ImageViewer.jsx
+++ b/frontend/src/ImageViewer.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import { Box } from '@mui/material'
+
+export default function ImageViewer({ file }) {
+  const [url, setUrl] = useState('')
+
+  useEffect(() => {
+    const objectUrl = URL.createObjectURL(file)
+    setUrl(objectUrl)
+    return () => URL.revokeObjectURL(objectUrl)
+  }, [file])
+
+  return (
+    <Box className="img-container">
+      {url && <img src={url} alt="Selected file" />}
+    </Box>
+  )
+}

--- a/frontend/src/PdfViewer.jsx
+++ b/frontend/src/PdfViewer.jsx
@@ -140,24 +140,25 @@ export default function PdfViewer({ file }) {
         <canvas ref={canvasRef} />
       </Box>
       <Box className="pdf-sidebar">
-        <Box className="pdf-mini-wrapper">
-          <canvas ref={miniCanvasRef} className="pdf-mini" />
-          <Box
-            className="pdf-mini-overlay"
-            sx={{
-              left: overlay.left,
-              top: overlay.top,
-              width: overlay.width,
-              height: overlay.height,
-            }}
-          />
-        </Box>
-        <Box className="pdf-controls">
-          <Box className="zoom-controls">
-            <Box className="zoom-buttons">
-              <IconButton onClick={zoomOut} size="small">
-                <ZoomOutIcon />
-              </IconButton>
+        <Box className="pdf-mini-section">
+          <Box className="pdf-mini-wrapper">
+            <canvas ref={miniCanvasRef} className="pdf-mini" />
+            <Box
+              className="pdf-mini-overlay"
+              sx={{
+                left: overlay.left,
+                top: overlay.top,
+                width: overlay.width,
+                height: overlay.height,
+              }}
+            />
+          </Box>
+          <Box className="pdf-controls">
+            <Box className="zoom-controls">
+              <Box className="zoom-buttons">
+                <IconButton onClick={zoomOut} size="small">
+                  <ZoomOutIcon />
+                </IconButton>
               <IconButton onClick={resetZoom} size="small">
                 <RefreshIcon />
               </IconButton>
@@ -169,6 +170,7 @@ export default function PdfViewer({ file }) {
               {Math.round(zoom * 100)}%
             </Typography>
           </Box>
+        </Box>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- allow selecting JPEG files in the start page
- show JPEG files using new `ImageViewer`
- add extra spacing after the title in the toolbar
- visually separate mini viewer/controls with a border
- support JPEG images in the file input

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68470a75c9e8833184cad58aa13d2dd5