### PR TITLE
Add mini map and zoom controls for JPG viewer

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -212,19 +212,66 @@
   align-items: flex-start;
 }
 
+
+.img-viewer {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: center;
+}
+
 .img-container {
   border: 1px solid #888;
   overflow: auto;
   display: inline-block;
   height: 90vh;
   width: 70vw;
+  position: relative;
 }
 
 .img-container img {
-  max-width: 100%;
-  max-height: 100%;
   display: block;
-  margin: 0 auto;
+  user-select: none;
+}
+
+.img-sidebar {
+  width: 250px;
+  border: 1px solid #888;
+  padding: 0.5rem;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.img-mini-section {
+  border-bottom: 1px solid #888;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.img-mini-wrapper {
+  position: relative;
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.img-mini {
+  width: 100%;
+  display: block;
+}
+
+.img-mini-overlay {
+  position: absolute;
+  border: 2px solid red;
+  pointer-events: none;
+  box-sizing: border-box;
+}
+
+.img-controls {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
 }
 
 

--- a/frontend/src/ImageViewer.jsx
+++ b/frontend/src/ImageViewer.jsx
@@ -1,8 +1,18 @@
-import { useEffect, useState } from 'react'
-import { Box } from '@mui/material'
+import { useEffect, useRef, useState } from 'react'
+import { Box, IconButton, Typography } from '@mui/material'
+import ZoomOutIcon from '@mui/icons-material/ZoomOut'
+import ZoomInIcon from '@mui/icons-material/ZoomIn'
+import RefreshIcon from '@mui/icons-material/Refresh'
 
 export default function ImageViewer({ file }) {
   const [url, setUrl] = useState('')
+  const [zoom, setZoom] = useState(1)
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 })
+  const [overlay, setOverlay] = useState({ left: 0, top: 0, width: 0, height: 0 })
+  const containerRef = useRef(null)
+  const imgRef = useRef(null)
+  const miniRef = useRef(null)
+  const dragState = useRef(null)
 
   useEffect(() => {
     const objectUrl = URL.createObjectURL(file)
@@ -10,9 +20,141 @@ export default function ImageViewer({ file }) {
     return () => URL.revokeObjectURL(objectUrl)
   }, [file])
 
+  const zoomIn = () => setZoom((z) => z * 1.2)
+  const zoomOut = () => setZoom((z) => z / 1.2)
+  const resetZoom = () => setZoom(1)
+
+  useEffect(() => {
+    const img = imgRef.current
+    if (!img) return
+    const update = () =>
+      setDimensions({ width: img.naturalWidth, height: img.naturalHeight })
+    if (img.complete) update()
+    else img.addEventListener('load', update)
+    return () => img.removeEventListener('load', update)
+  }, [url])
+
+  useEffect(() => {
+    const img = imgRef.current
+    if (!img) return
+    img.style.width = `${dimensions.width * zoom}px`
+    img.style.height = `${dimensions.height * zoom}px`
+  }, [zoom, dimensions])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const canPan =
+      container.scrollWidth > container.clientWidth ||
+      container.scrollHeight > container.clientHeight
+    container.style.cursor = canPan ? 'grab' : 'default'
+  }, [zoom, dimensions])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const handleDown = (e) => {
+      const canPan =
+        container.scrollWidth > container.clientWidth ||
+        container.scrollHeight > container.clientHeight
+      if (!canPan) return
+      dragState.current = {
+        x: e.clientX,
+        y: e.clientY,
+        scrollLeft: container.scrollLeft,
+        scrollTop: container.scrollTop,
+      }
+      container.style.cursor = 'grabbing'
+      e.preventDefault()
+    }
+    const handleMove = (e) => {
+      if (!dragState.current) return
+      const dx = e.clientX - dragState.current.x
+      const dy = e.clientY - dragState.current.y
+      container.scrollLeft = dragState.current.scrollLeft - dx
+      container.scrollTop = dragState.current.scrollTop - dy
+    }
+    const endDrag = () => {
+      if (!dragState.current) return
+      dragState.current = null
+      container.style.cursor = 'grab'
+    }
+    container.addEventListener('mousedown', handleDown)
+    container.addEventListener('mousemove', handleMove)
+    container.addEventListener('mouseleave', endDrag)
+    window.addEventListener('mouseup', endDrag)
+    return () => {
+      container.removeEventListener('mousedown', handleDown)
+      container.removeEventListener('mousemove', handleMove)
+      container.removeEventListener('mouseleave', endDrag)
+      window.removeEventListener('mouseup', endDrag)
+    }
+  }, [zoom, dimensions])
+
+  useEffect(() => {
+    const mini = miniRef.current
+    if (!mini || !url) return
+    const scale = mini.clientWidth / dimensions.width
+    mini.style.height = `${dimensions.height * scale}px`
+  }, [dimensions, url])
+
+  useEffect(() => {
+    const container = containerRef.current
+    const mini = miniRef.current
+    if (!container || !mini || !dimensions.width) return
+    const scale = mini.clientWidth / dimensions.width
+    const updateOverlay = () => {
+      setOverlay({
+        left: (container.scrollLeft / zoom) * scale,
+        top: (container.scrollTop / zoom) * scale,
+        width: (container.clientWidth / zoom) * scale,
+        height: (container.clientHeight / zoom) * scale,
+      })
+    }
+    updateOverlay()
+    container.addEventListener('scroll', updateOverlay)
+    return () => container.removeEventListener('scroll', updateOverlay)
+  }, [zoom, dimensions])
+
   return (
-    <Box className="img-container">
-      {url && <img src={url} alt="Selected file" />}
+    <Box className="img-viewer">
+      <Box className="img-container" ref={containerRef}>
+        {url && <img ref={imgRef} src={url} alt="Selected file" draggable="false" />}
+      </Box>
+      <Box className="img-sidebar">
+        <Box className="img-mini-section">
+          <Box className="img-mini-wrapper">
+            {url && <img ref={miniRef} src={url} className="img-mini" alt="preview" />}
+            <Box
+              className="img-mini-overlay"
+              sx={{
+                left: overlay.left,
+                top: overlay.top,
+                width: overlay.width,
+                height: overlay.height,
+              }}
+            />
+          </Box>
+          <Box className="img-controls">
+            <Box className="zoom-controls">
+              <Box className="zoom-buttons">
+                <IconButton onClick={zoomOut} size="small">
+                  <ZoomOutIcon />
+                </IconButton>
+                <IconButton onClick={resetZoom} size="small">
+                  <RefreshIcon />
+                </IconButton>
+                <IconButton onClick={zoomIn} size="small">
+                  <ZoomInIcon />
+                </IconButton>
+              </Box>
+              <Typography className="zoom-indicator">
+                {Math.round(zoom * 100)}%
+              </Typography>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
## Summary
- enhance image viewer with zoom and panning features
- add miniature preview window with overlay
- show zoom controls and percentage indicator
- style new image viewer elements

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847102ab6d083319f84a17d08e61fec