### PR TITLE
Adjust icon palette and marker interactions

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -299,6 +299,13 @@
   height: 32px;
   pointer-events: auto;
   cursor: move;
+  transition: transform 0.1s;
+}
+
+.config-marker:hover,
+.config-marker.dragging {
+  transform: scale(1.2);
+  cursor: grab;
 }
 
 .icon-container {
@@ -315,7 +322,7 @@
 }
 
 .palette-icon {
-  width: 100px;
-  height: 100px;
+  width: 65px;
+  height: 65px;
   user-select: none;
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -322,7 +322,7 @@
 }
 
 .palette-icon {
-  width: 65px;
-  height: 65px;
+  width: 54px;
+  height: 54px;
   user-select: none;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -43,9 +43,11 @@ function App() {
           </Button>
         </Toolbar>
       </AppBar>
-      <Box className="icon-container">
-        <IconPalette />
-      </Box>
+      {file && (
+        <Box className="icon-container">
+          <IconPalette />
+        </Box>
+      )}
       <Container sx={{ mt: 2 }}>
         {file && fileType === 'pdf' && <PdfViewer file={file} />}
         {file && fileType === 'dwg' && <DwgViewer file={file} />}

--- a/frontend/src/DwgViewer.jsx
+++ b/frontend/src/DwgViewer.jsx
@@ -55,6 +55,9 @@ export default function DwgViewer({ file }) {
   }
   const handleMarkerDown = (index) => (e) => {
     e.stopPropagation()
+    e.preventDefault()
+    const el = e.currentTarget
+    el.classList.add('dragging')
     const startX = e.clientX
     const startY = e.clientY
     const startPos = markers[index]
@@ -70,6 +73,7 @@ export default function DwgViewer({ file }) {
     const up = () => {
       window.removeEventListener('pointermove', move)
       window.removeEventListener('pointerup', up)
+      el.classList.remove('dragging')
     }
     window.addEventListener('pointermove', move)
     window.addEventListener('pointerup', up)

--- a/frontend/src/ImageViewer.jsx
+++ b/frontend/src/ImageViewer.jsx
@@ -27,6 +27,7 @@ export default function ImageViewer({ file }) {
   }
   const handleMarkerDown = (index) => (e) => {
     e.stopPropagation()
+    e.preventDefault()
     const el = e.currentTarget
     el.classList.add('dragging')
     const startX = e.clientX

--- a/frontend/src/ImageViewer.jsx
+++ b/frontend/src/ImageViewer.jsx
@@ -27,6 +27,8 @@ export default function ImageViewer({ file }) {
   }
   const handleMarkerDown = (index) => (e) => {
     e.stopPropagation()
+    const el = e.currentTarget
+    el.classList.add('dragging')
     const startX = e.clientX
     const startY = e.clientY
     const startPos = markers[index]
@@ -42,6 +44,7 @@ export default function ImageViewer({ file }) {
     const up = () => {
       window.removeEventListener('pointermove', move)
       window.removeEventListener('pointerup', up)
+      el.classList.remove('dragging')
     }
     window.addEventListener('pointermove', move)
     window.addEventListener('pointerup', up)

--- a/frontend/src/PdfViewer.jsx
+++ b/frontend/src/PdfViewer.jsx
@@ -31,6 +31,9 @@ export default function PdfViewer({ file }) {
   }
   const handleMarkerDown = (index) => (e) => {
     e.stopPropagation()
+    e.preventDefault()
+    const el = e.currentTarget
+    el.classList.add('dragging')
     const startX = e.clientX
     const startY = e.clientY
     const startPos = markers[index]
@@ -46,6 +49,7 @@ export default function PdfViewer({ file }) {
     const up = () => {
       window.removeEventListener('pointermove', move)
       window.removeEventListener('pointerup', up)
+      el.classList.remove('dragging')
     }
     window.addEventListener('pointermove', move)
     window.addEventListener('pointerup', up)


### PR DESCRIPTION
## Summary
- hide icon palette until a file is loaded
- make palette icons 65x65
- highlight markers when hovered or dragging
- add dragging class handling in `ImageViewer`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684738ea6b48833198196a2ed7d5e9e5