### PR TITLE
Center icon and set theme color

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -326,3 +326,9 @@
   height: 54px;
   user-select: none;
 }
+
+.start-icon {
+  width: 200px;
+  display: block;
+  margin: 2rem auto 0;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import icon from './assets/icon.png'
 import {
   AppBar,
   Toolbar,
@@ -43,6 +44,11 @@ function App() {
           </Button>
         </Toolbar>
       </AppBar>
+      {!file && (
+        <Box sx={{ mt: 4, textAlign: 'center' }}>
+          <img src={icon} alt="App icon" className="start-icon" />
+        </Box>
+      )}
       {file && (
         <Box className="icon-container">
           <IconPalette />

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,7 +4,13 @@ import { CssBaseline, ThemeProvider, createTheme } from '@mui/material'
 import './index.css'
 import App from './App.jsx'
 
-const theme = createTheme()
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#085e21',
+    },
+  },
+})
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- display `icon.png` on start page when no file is loaded
- use the icon's green for the MUI theme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849c85bede48331a7c5e6808d73fba5